### PR TITLE
feat(api): add async /batch-remove-bg with ZIP + single /remove-bg

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,124 @@
+# backend/main.py
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+from typing import List
+from pathlib import Path
+from dotenv import load_dotenv
+import os, io, zipfile, asyncio, httpx
+
+# --- Load backend/.env explicitly ---
+ENV_PATH = Path(__file__).resolve().parent / ".env"
+load_dotenv(dotenv_path=ENV_PATH)
+
+API_KEY = os.getenv("REMOVE_BG_API_KEY")
+if not API_KEY:
+    raise RuntimeError(f"REMOVE_BG_API_KEY missing in {ENV_PATH}")
+
+REMOVE_BG_URL = "https://api.remove.bg/v1.0/removebg"
+
+# --- FastAPI app ---
+app = FastAPI(title="DIP Background Removal API")
+
+# Allow Vite dev server to call the backend
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.get("/")
+def root():
+    return {"ok": True, "service": "remove.bg bridge"}
+
+@app.get("/health")
+def health():
+    return {"status": "up"}
+
+# ---------- Single image ----------
+@app.post("/remove-bg")
+async def remove_bg(file: UploadFile = File(...), size: str = "auto"):
+    img_bytes = await file.read()
+    async with httpx.AsyncClient(timeout=60) as client:
+        try:
+            r = await client.post(
+                REMOVE_BG_URL,
+                files={"image_file": (file.filename or "upload.png", img_bytes)},
+                data={"size": size},
+                headers={"X-Api-Key": API_KEY},
+            )
+        except Exception as e:
+            raise HTTPException(500, f"Request failed: {e}")
+
+    if r.status_code != 200:
+        raise HTTPException(r.status_code, r.text)
+
+    headers = {
+        "Content-Disposition": 'inline; filename="output.png"',
+        "Cache-Control": "no-store",
+    }
+    return StreamingResponse(iter([r.content]), media_type="image/png", headers=headers)
+
+# ---------- Batch (async + concurrent) ----------
+def _png_name(name: str) -> str:
+    return f"{Path(name).stem or 'image'}.png"
+
+@app.post("/batch-remove-bg")
+async def batch_remove_bg(
+    files: List[UploadFile] = File(...),
+    size: str = "auto",
+    concurrent: int = 3,   # tune if you hit 429 (rate-limit)
+    as_zip: bool = True    # true => return a ZIP of PNGs
+):
+    if not files:
+        raise HTTPException(400, "No files uploaded")
+
+    # Read all uploads concurrently
+    contents = await asyncio.gather(*[f.read() for f in files])
+    names = [f.filename or f"image_{i}.png" for i, f in enumerate(files)]
+
+    sem = asyncio.Semaphore(max(1, min(concurrent, 8)))  # safety cap
+
+    async def process_one(name: str, data: bytes, client: httpx.AsyncClient):
+        async with sem:
+            try:
+                r = await client.post(
+                    REMOVE_BG_URL,
+                    files={"image_file": (name, data)},
+                    data={"size": size},
+                    headers={"X-Api-Key": API_KEY},
+                    timeout=60,
+                )
+                if r.status_code == 200:
+                    return {"filename": name, "ok": True, "content": r.content}
+                return {"filename": name, "ok": False, "status": r.status_code, "error": r.text}
+            except Exception as e:
+                return {"filename": name, "ok": False, "status": 500, "error": str(e)}
+
+    async with httpx.AsyncClient() as client:
+        results = await asyncio.gather(
+            *[process_one(n, d, client) for n, d in zip(names, contents)]
+        )
+
+    if as_zip:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as z:
+            for res in results:
+                if res.get("ok"):
+                    z.writestr(_png_name(res["filename"]), res["content"])
+                else:
+                    msg = f"Failed: {res.get('status')} {res.get('error','')}".strip()
+                    z.writestr(f"{_png_name(res['filename'])}.error.txt", msg or "Unknown error")
+        buf.seek(0)
+        headers = {"Content-Disposition": 'attachment; filename="cutouts.zip"'}
+        return StreamingResponse(buf, media_type="application/zip", headers=headers)
+
+    # JSON summary (no images)
+    return {
+        "processed": len(results),
+        "success": sum(1 for r in results if r.get("ok")),
+        "failed": sum(1 for r in results if not r.get("ok")),
+        "results": [{k: v for k, v in r.items() if k != "content"} for r in results],
+    }

--- a/backend/remove_bg_service.py
+++ b/backend/remove_bg_service.py
@@ -1,0 +1,76 @@
+import os
+import requests
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+class RemoveBGService:
+    def __init__(self):
+        self.api_key = os.getenv('REMOVE_BG_API_KEY')
+        self.api_url = "https://api.remove.bg/v1.0/removebg"
+        
+        if not self.api_key:
+            raise ValueError("REMOVE_BG_API_KEY not found in environment variables")
+    
+    def remove_background(self, image_path, output_path):
+        """
+        Remove background from an image using remove.bg API
+        """
+        try:
+            files = {'image_file': open(image_path, 'rb')}
+            data = {'size': 'auto'}
+            headers = {'X-Api-Key': self.api_key}
+            
+            response = requests.post(
+                self.api_url,
+                files=files,
+                data=data,
+                headers=headers
+            )
+            
+            if response.status_code == requests.codes.ok:
+                with open(output_path, 'wb') as out:
+                    out.write(response.content)
+                print(f"✅ Background removed successfully! Saved to: {output_path}")
+                return True
+            else:
+                print(f"❌ Error: {response.status_code}, {response.text}")
+                return False
+                
+        except Exception as e:
+            print(f"❌ Exception occurred: {str(e)}")
+            return False
+        finally:
+            if 'files' in locals():
+                files['image_file'].close()
+
+def test_remove_bg():
+    service = RemoveBGService()
+    
+    # Automatically detect first image in test_images folder
+    folder = 'test_images'
+    if not os.path.exists(folder):
+        print(f"❌ Folder not found: {folder}")
+        return
+    
+    # Find first .png or .jpg file
+    candidates = [f for f in os.listdir(folder) if f.lower().endswith(('.png', '.jpg', '.jpeg'))]
+    if not candidates:
+        print(f"⚠️  Please add a test image (.png or .jpg) in '{folder}' first")
+        return
+    
+    input_image = os.path.join(folder, candidates[0])  # use first image found
+    output_image = os.path.join(folder, "output.png")
+    
+    print(f"🔍 Using input image: {input_image}")
+    success = service.remove_background(input_image, output_image)
+    if success:
+        print("🎉 Background removal test passed!")
+        import webbrowser
+        webbrowser.open(os.path.abspath(output_image))
+    else:
+        print("❌ Background removal test failed!")
+
+if __name__ == "__main__":
+    test_remove_bg()

--- a/backend/run_remove_bg.py
+++ b/backend/run_remove_bg.py
@@ -1,0 +1,11 @@
+import os
+from remove_bg_service import RemoveBGService
+
+# Paths relative to repo root; adjust if your file is elsewhere
+INPUT  = os.path.join("backend", "test_images", "Input.png")
+OUTPUT = os.path.join("backend", "test_images", "Output.png")
+
+if __name__ == "__main__":
+    svc = RemoveBGService()
+    ok = svc.remove_background(INPUT, OUTPUT)
+    print("Success?" , ok)


### PR DESCRIPTION
- Endpoints:
  - POST /remove-bg (single)
  - POST /batch-remove-bg (async + concurrent, returns ZIP)
- Loads key from backend/.env (REMOVE_BG_API_KEY)
- CORS allows http://localhost:5173

How to run:
conda activate ee3180_backend
pip install fastapi uvicorn python-dotenv httpx python-multipart aiofiles requests
uvicorn backend.main:app --reload  # http://127.0.0.1:8000/docs
